### PR TITLE
tests: add missing tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
       - main
 
 jobs:
-  test:
+  anchor-test:
     name: Anchor Test
     runs-on: ubuntu-latest
     steps:
@@ -28,5 +28,16 @@ jobs:
           anchor-version: "${{steps.anchor.outputs.version}}"
           solana-cli-version: "${{steps.solana.outputs.version}}"
 
+  rust-checks:
+    name: Rust Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
       - run: cargo fmt --check --all
       - run: cargo clippy
+      - run: cargo test

--- a/programs/solana-world-id-program/src/instructions/update_root_with_query.rs
+++ b/programs/solana-world-id-program/src/instructions/update_root_with_query.rs
@@ -42,6 +42,12 @@ cfg_if::cfg_if! {
 // web3.eth.abi.encodeFunctionSignature("latestRoot()");
 pub const LATEST_ROOT_SIGNATURE: [u8; 4] = [0xd7, 0xb0, 0xfe, 0xf1];
 
+#[test]
+fn test_latest_root_signature() {
+    let hash = solana_program::keccak::hashv(&[b"latestRoot()"]).to_bytes();
+    assert_eq!(LATEST_ROOT_SIGNATURE, hash[0..4]);
+}
+
 /// Compute quorum based on the number of guardians in a guardian set.
 #[inline]
 pub fn quorum(num_guardians: usize) -> usize {

--- a/programs/solana-world-id-program/src/state/query_signature_set.rs
+++ b/programs/solana-world-id-program/src/state/query_signature_set.rs
@@ -21,7 +21,7 @@ pub struct QuerySignatureSet {
 
 impl QuerySignatureSet {
     pub fn is_initialized(&self) -> bool {
-        self.sig_verify_successes.iter().any(|&value| value)
+        !self.sig_verify_successes.is_empty()
     }
 
     pub fn num_verified(&self) -> usize {

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,10 +16,19 @@ The goal of these tests is to provide positive and negative cases for account an
   - [x] Rejects guardian set mismatch
   - [x] Rejects message mismatch
   - [x] Rejects invalid guardian key recovery
+  - [x] Rejects when there's no preceding Secp256k1 instruction
+  - [x] Rejects when preceding instruction is not Secp256k1
+  - [x] Rejects message with incorrect size
+  - [ ] Rejects mismatched signature instruction index
+  - [ ] Rejects mismatched eth_pubkey instruction index
+  - [ ] Rejects mismatched message instruction index
+  - [x] Rejects empty sig verify instruction
 - [x] [update_root_with_query](/programs/solana-world-id-program/src/instructions/update_root_with_query.rs)
   - [x] Successfully verifies mock queries and updates root
   - [x] Successfully closed the signature set
   - [x] Successfully verifies and updates subsequent root
+  - [x] Successfully updates root with maximum allowed staleness
+  - [x] Successfully handles allowed update staleness underflow gracefully
   - [x] Rejects valid root which already exists
   - [x] Rejects guardian set account mismatch
   - [x] Rejects refund recipient account mismatch
@@ -57,6 +66,7 @@ The goal of these tests is to provide positive and negative cases for account an
   - [x] Rejects owner account mismatch
   - [x] Rejects without owner as signer
   - [x] Rejects incorrect program_data
+  - [x] Rejects when upgrade_lock account is incorrect
   - [ ] Rejects when authority is already upgrade lock (test in devnet)
 - [ ] [claim_ownership](/programs/solana-world-id-program/src/instructions/admin.rs)
   - [ ] Successfully completes ownership transfer (test in devnet)

--- a/tests/helpers/verifySignature.ts
+++ b/tests/helpers/verifySignature.ts
@@ -17,7 +17,8 @@ export async function createVerifyQuerySignaturesInstructions(
   signatures: string[],
   signatureSet: anchor.web3.PublicKey,
   commitment?: anchor.web3.Commitment,
-  guardianSetIndex?: number
+  guardianSetIndex?: number,
+  emptySigVerify = false
 ): Promise<anchor.web3.TransactionInstruction[]> {
   const MAX_LEN_GUARDIAN_KEYS = 19;
 
@@ -64,7 +65,12 @@ export async function createVerifyQuerySignaturesInstructions(
       signatureStatus[item.index] = j;
     }
 
-    instructions.push(createSecp256k1Instruction(signatures, keys, hash));
+    // for when we want to test the case where the signatures is empty
+    // `EmptySigVerifyInstruction` will be thrown
+    const sigVerifyInstruction = emptySigVerify
+      ? createSecp256k1Instruction([], [], hash)
+      : createSecp256k1Instruction(signatures, keys, hash);
+    instructions.push(sigVerifyInstruction);
 
     const ix = await program.methods
       .verifyQuerySignatures(signatureStatus)


### PR DESCRIPTION
PR does a few things:
- test `LATEST_ROOT_SIGNATURE` constant 
- change `QuerySignatureSet.is_initialized()` to check if `sig_verify_success` is empty
- add missing tests (check diff in `tests/README.md`)
- `createSecp256k1Instruction`
    - update docs
    - return empty sig verification data for testing `EmptySigVerificationData`
    - remove constraint of message length = 67 for negative testing `QUERY_MESSAGE_LENGTH`_ check
- add rust check to github workflows