### PR TITLE
verify_and_execute:

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -8,6 +8,7 @@ skip-lint = false
 
 [programs.localnet]
 solana_world_id_program = "9QwAWx3TKg4CaTjHNhBefQeNSzEKDe2JDxL46F76tVDv"
+solana_world_id_example_program = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 [registry]
 url = "https://api.apr.dev"
@@ -17,7 +18,7 @@ cluster = "Localnet"
 wallet = "tests/keys/pFCBP4bhqdSsrWUVTgqhPsLrfEdChBK17vgFM7TxjxQ.json"
 
 [scripts]
-test = "npx tsc --noEmit && yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/solana-world-id-program.ts"
+test = "npx tsc --noEmit && yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/solana-world-id-program.ts tests/solana-world-id-example-program.ts"
 
 [test]
 upgradeable = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "ethnum"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+
+[[package]]
 name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +869,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -1598,6 +1610,22 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.67",
+]
+
+[[package]]
+name = "solana-world-id-example-program"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "cfg-if",
+ "ethnum",
+ "groth16-solana",
+ "hex",
+ "solana-program",
+ "solana-world-id-program",
+ "wormhole-query-sdk",
+ "wormhole-solana-consts",
+ "wormhole-solana-utils",
 ]
 
 [[package]]

--- a/programs/solana-world-id-example-program/Cargo.toml
+++ b/programs/solana-world-id-example-program/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "solana-world-id-example-program"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "solana_world_id_example_program"
+
+[features]
+default = ["mainnet"]
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+mainnet = ["wormhole-solana-consts/mainnet"]
+testnet = ["wormhole-solana-consts/testnet"]
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { version = "0.30.1", features = ["init-if-needed"] }
+cfg-if = "1.0"
+wormhole-solana-consts = {version = "0.3.0-alpha.1"}
+wormhole-solana-utils = {version = "0.3.0-alpha.1"}
+wormhole-query-sdk = { git = "https://github.com/wormholelabs-xyz/wormhole-query-sdk-rust", version = "0.0.1", rev = "0f34cb470f4e3137b53aa91adcbb0c7def280925" }
+groth16-solana = "0.0.3"
+solana-program = "1.18.17"
+solana-world-id-program = { path = "../solana-world-id-program", features = ["cpi"] }
+ethnum = "1.3.2"
+hex = "0.4.3"

--- a/programs/solana-world-id-example-program/src/instructions/mod.rs
+++ b/programs/solana-world-id-example-program/src/instructions/mod.rs
@@ -1,0 +1,2 @@
+mod verify_and_execute;
+pub use verify_and_execute::*;

--- a/programs/solana-world-id-example-program/src/instructions/verify_and_execute.rs
+++ b/programs/solana-world-id-example-program/src/instructions/verify_and_execute.rs
@@ -1,0 +1,129 @@
+use anchor_lang::{
+    prelude::*,
+    solana_program::{self},
+};
+use ethnum::U256;
+use solana_program::keccak::hash;
+use solana_world_id_program::cpi::accounts::VerifyGroth16Proof;
+use solana_world_id_program::program::SolanaWorldIdProgram;
+use solana_world_id_program::state::Root;
+
+// Hardcoded examples
+pub const APP_ID: &str = "app_staging_7d23b838b02776cebd87b86ac3248641";
+pub const ACTION: &str = "testing";
+pub const VERIFICATION_TYPE: [u8; 1] = [0u8]; // For query-based verification
+
+#[derive(Accounts)]
+#[instruction(args: VerifyAndExecuteArgs)]
+pub struct VerifyAndExecute<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    #[account(
+        seeds = [
+            Root::SEED_PREFIX,
+            &args.root_hash,
+            &[0u8], // verification_type for query
+        ],
+        bump,
+        seeds::program = solana_world_id_program::ID
+    )]
+    pub root: Account<'info, Root>,
+
+    /// CHECK: This account is the recipient and must exist, but can be any type of account
+    pub recipient: UncheckedAccount<'info>,
+
+    /// CHECK: This account is used as a PDA to ensure uniqueness and is not read or written to
+    #[account(
+        init,
+        payer = payer,
+        space = 0,
+        seeds = [b"nullifier", args.nullifier_hash.as_ref()],
+        bump,
+    )]
+    pub nullifier: AccountInfo<'info>,
+
+    pub world_id_program: Program<'info, SolanaWorldIdProgram>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct VerifyAndExecuteArgs {
+    pub root_hash: [u8; 32],
+    pub nullifier_hash: [u8; 32],
+    pub proof: [u8; 256],
+}
+
+fn hash_to_field(input: &[u8]) -> [u8; 32] {
+    let hash_result = hash(input).to_bytes();
+    let big_int: U256 = U256::from_be_bytes(hash_result);
+    let shifted: U256 = big_int >> 8;
+    let result = shifted.to_be_bytes();
+    result
+}
+
+fn app_id_action_to_external_nullifier_hash(app_id: &str, action: &str) -> [u8; 32] {
+    let app_hash = hash_to_field(app_id.as_bytes());
+    let mut combined = app_hash.to_vec();
+    combined.extend_from_slice(action.as_bytes());
+    hash_to_field(&combined)
+}
+
+/// Parameters for the `verify_and_execute` function:
+///
+/// - `ctx`: The context containing all the accounts required for the instruction.
+/// - `args`: The arguments for the `verify_and_execute` instruction, which include:
+///   - `root_hash`: A 32-byte array representing the root hash of the Merkle tree.
+///   - `nullifier_hash`: A 32-byte array representing the hash of the nullifier to ensure uniqueness.
+///   - `proof`: A 256-byte array containing the Groth16 proof for verification.
+///
+/// The function performs the following steps:
+/// 1. Calculates the `external_nullifier_hash` using the `APP_ID` and `ACTION`.
+/// 2. Converts the recipient's public key to a hex string and hashes it to get the `signal_hash`.
+///    Note: The proof is generated using the recipient's public key converted to bytes and then to a hex string.
+///    This is equivalent to `publicKey.toBuffer().toString('hex')` in JavaScript/TypeScript.
+/// 3. Makes a CPI call to the `verify_groth16_proof` function in the `solana_world_id_program` to verify the proof.
+///
+/// Important: When generating the proof off-chain, ensure that the signal (recipient's public key)
+/// is processed in the same way: convert the public key to bytes, then to a hex string. This ensures
+/// that the on-chain verification matches the off-chain proof generation.
+///
+/// Example:
+/// In JavaScript/TypeScript, the signal would be generated like this:
+/// ```javascript
+/// const signal = `0x${new PublicKey('5yNbCZcCHeAxdmMJXcpFgmurEnygaVbCRwZNMMWETdeZ')
+///   .toBuffer()
+///   .toString('hex')}`;
+/// ```
+/// This produces a hex string that matches what the on-chain program uses for verification.
+pub fn verify_and_execute(
+    ctx: Context<VerifyAndExecute>,
+    args: VerifyAndExecuteArgs,
+) -> Result<()> {
+    // Calculate external_nullifier_hash
+    let external_nullifier_hash: [u8; 32] =
+        app_id_action_to_external_nullifier_hash(APP_ID, ACTION);
+
+    // Calculate the signal hash by converting the recipient key to hex and hashing it˝
+    let signal_bytes = ctx.accounts.recipient.key().to_bytes();
+    let signal_hash = hash_to_field(&signal_bytes);
+
+    // CPI call to verify_groth16_proof
+    solana_world_id_program::cpi::verify_groth16_proof(
+        CpiContext::new(
+            ctx.accounts.world_id_program.to_account_info(),
+            VerifyGroth16Proof {
+                root: ctx.accounts.root.to_account_info(),
+            },
+        ),
+        args.root_hash,
+        VERIFICATION_TYPE,
+        signal_hash,
+        args.nullifier_hash,
+        external_nullifier_hash,
+        args.proof,
+    )?;
+
+    Ok(())
+}

--- a/programs/solana-world-id-example-program/src/lib.rs
+++ b/programs/solana-world-id-example-program/src/lib.rs
@@ -1,0 +1,17 @@
+use anchor_lang::prelude::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+mod instructions;
+pub(crate) use instructions::*;
+
+#[program]
+pub mod solana_world_id_example_program {
+    use super::*;
+    pub fn verify_and_execute(
+        ctx: Context<VerifyAndExecute>,
+        args: VerifyAndExecuteArgs,
+    ) -> Result<()> {
+        instructions::verify_and_execute(ctx, args)
+    }
+}

--- a/tests/helpers/fmtTest.ts
+++ b/tests/helpers/fmtTest.ts
@@ -1,0 +1,4 @@
+const fmtTest = (instruction: string, name: string) =>
+  `${instruction.padEnd(30)} ${name}`;
+
+export default fmtTest;

--- a/tests/helpers/verifyQuerySigs.ts
+++ b/tests/helpers/verifyQuerySigs.ts
@@ -1,0 +1,41 @@
+import * as anchor from "@coral-xyz/anchor";
+import { createVerifyQuerySignaturesInstructions } from "./verifySignature";
+import { SolanaWorldIdProgram } from "../../target/types/solana_world_id_program";
+
+const coreBridgeAddress = new anchor.web3.PublicKey(
+  "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+);
+const mockGuardianSetIndex = 5;
+
+async function verifyQuerySigs(
+  program: anchor.Program<SolanaWorldIdProgram>,
+  queryBytes: string,
+  querySignatures: string[],
+  signatureSet: anchor.web3.Keypair,
+  wormholeProgramId: anchor.web3.PublicKey = coreBridgeAddress,
+  guardianSetIndex: number = mockGuardianSetIndex
+) {
+  const p = anchor.getProvider();
+  const instructions = await createVerifyQuerySignaturesInstructions(
+    p.connection,
+    program,
+    wormholeProgramId,
+    p.publicKey,
+    queryBytes,
+    querySignatures,
+    signatureSet.publicKey,
+    undefined,
+    guardianSetIndex
+  );
+  const unsignedTransactions: anchor.web3.Transaction[] = [];
+  for (let i = 0; i < instructions.length; i += 2) {
+    unsignedTransactions.push(
+      new anchor.web3.Transaction().add(...instructions.slice(i, i + 2))
+    );
+  }
+  for (const tx of unsignedTransactions) {
+    await p.sendAndConfirm(tx, [signatureSet]);
+  }
+}
+
+export default verifyQuerySigs;

--- a/tests/solana-world-id-example-program.ts
+++ b/tests/solana-world-id-example-program.ts
@@ -1,0 +1,146 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { SolanaWorldIdExampleProgram } from "../target/types/solana_world_id_example_program";
+import { SolanaWorldIdProgram } from "../target/types/solana_world_id_program";
+import { assert, expect } from "chai";
+import { deriveRootKey } from "./helpers/root";
+import fmtTest from "./helpers/fmtTest";
+import { PublicKey } from "@solana/web3.js";
+import { sign } from "@wormhole-foundation/wormhole-query-sdk";
+import { hashToField } from "./helpers/utils/hashing";
+
+describe("solana-world-id-example-program", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace
+    .SolanaWorldIdExampleProgram as Program<SolanaWorldIdExampleProgram>;
+  const worldIdProgram = anchor.workspace
+    .SolanaWorldIdProgram as Program<SolanaWorldIdProgram>;
+
+  // Generated with WorldCoin ID Example template using Solana pubkey as a signal
+  const idkitSuccessResult = {
+    proof:
+      "0x177606b1626d9de53cca760de8907c122dcd7a0a8e36d6714785643b11604a61290b36c88275913ac7a0493e43362eff9e75cfc407e8fb3baab5b70323f29dbe0aa915653679af4671b1abbe0d79d2f08ee30696b336b81321f6d21ef0817c641177998bcd88a114cec8fe64783ba28f3fb1cc7b82e6438a414596ec1d2a606010a45353ded3a594f599b6d4abbde58d6f64e2a1d705cdaa6850400eb58312392d56bba2718764fc9062b92159314937a9683f491e0e77253cd3a1000ce601632383b56798f90d32756497d00aab3ed4520ab743e1718fcd0707435e1cf24bfd23eb1717e04b27c3b9c98d098ab8f876f5a6fa72d2dccc6850f7c98d80d7549a",
+    merkle_root:
+      "0x29e7081a4cb49cd0119c81d766d9ca41cbdfaf3ce21c8ae0963b8d1b15db4d9a",
+    nullifier_hash:
+      "0x2aa975196dc1f4f9f57b8195bea9c61331e0012ec25484ed569782c49145721a",
+    verification_level: "orb",
+  };
+
+  const rootHash = [
+    ...Buffer.from(idkitSuccessResult.merkle_root.substring(2), "hex"),
+  ];
+  // Random Solana pubkey generated for testing
+  const recipient = "5yNbCZcCHeAxdmMJXcpFgmurEnygaVbCRwZNMMWETdeZ";
+
+  const nullifierHash = [
+    ...Buffer.from(idkitSuccessResult.nullifier_hash.substring(2), "hex"),
+  ];
+  const proof = [...Buffer.from(idkitSuccessResult.proof.substring(2), "hex")];
+
+  async function verifyAndExecute(
+    rootHash: number[],
+    nullifierHash: number[],
+    proof: number[],
+    recipientPublicKey: string
+  ) {
+    return program.methods
+      .verifyAndExecute({
+        rootHash: rootHash,
+        nullifierHash: nullifierHash,
+        proof: proof,
+      })
+      .accounts({
+        payer: provider.wallet.publicKey,
+        root: deriveRootKey(worldIdProgram.programId, Buffer.from(rootHash), 0),
+        recipient: new PublicKey(recipientPublicKey),
+      })
+      .accountsPartial({
+        nullifier: anchor.web3.PublicKey.findProgramAddressSync(
+          [
+            Buffer.from("nullifier"),
+            Buffer.from(idkitSuccessResult.nullifier_hash.substring(2), "hex"),
+          ],
+          program.programId
+        )[0],
+        worldIdProgram: worldIdProgram.programId,
+        systemProgram: anchor.web3.SystemProgram.programId,
+      })
+      .rpc();
+  }
+
+  it(
+    fmtTest("verify_and_execute", "Rejects mismatched root hash"),
+    async () => {
+      const invalidRootHash = new Array(32).fill(0); // Create an array of 32 zeros
+      await expect(
+        verifyAndExecute(invalidRootHash, nullifierHash, proof, recipient)
+      ).to.be.rejected;
+    }
+  );
+
+  it(
+    fmtTest("verify_and_execute", "Rejects invalid nullifier hash"),
+    async () => {
+      const invalidNullifierHash = new Array(32).fill(0); // Create an array of 32 zeros
+      await expect(
+        verifyAndExecute(rootHash, invalidNullifierHash, proof, recipient)
+      ).to.be.rejected;
+    }
+  );
+
+  it(fmtTest("verify_and_execute", "Rejects different recipient"), async () => {
+    const differentRecipient = "5yNbCZcCHeAxdmMJXcpFgmurEnygaVbCRwZNMMWETdeA";
+    await expect(
+      verifyAndExecute(rootHash, nullifierHash, proof, differentRecipient)
+    ).to.be.rejected;
+  });
+
+  it(
+    fmtTest(
+      "verify_and_execute",
+      "Successfully verifies and adds nullifier PDA"
+    ),
+    async () => {
+      await expect(verifyAndExecute(rootHash, nullifierHash, proof, recipient))
+        .to.be.fulfilled;
+
+      // Add assertions here to check if the verification was successful
+      const [nullifierPda] = anchor.web3.PublicKey.findProgramAddressSync(
+        [
+          Buffer.from("nullifier"),
+          Buffer.from(idkitSuccessResult.nullifier_hash.substring(2), "hex"),
+        ],
+        program.programId
+      );
+
+      const connection = program.provider.connection;
+      const nullifierAccountInfo = await connection.getAccountInfo(
+        nullifierPda
+      );
+
+      assert(nullifierAccountInfo !== null, "Nullifier PDA should exist");
+      assert(
+        nullifierAccountInfo!.owner.equals(program.programId),
+        "Nullifier PDA should be owned by the program"
+      );
+      assert(
+        nullifierAccountInfo!.data.length === 0,
+        "Nullifier PDA should have no data"
+      );
+    }
+  );
+
+  it(
+    fmtTest("verify_and_execute", "Rejects nullifier already used"),
+    async () => {
+      await expect(
+        verifyAndExecute(rootHash, nullifierHash, proof, recipient)
+      ).to.be.rejectedWith(
+        "Allocate: account Address { address: 9H5hoPdn4mSStDV4y2Pbc3oqkdUoRrqvdPzAP5bZC6hm, base: None } already in use"
+      );
+    }
+  );
+});


### PR DESCRIPTION
This PR includes:
1. New solana program with instruction `verify_and_execute`
2. `verify_and_execute`:
    - works as a Solana parallel for [WorldID onchain template](https://github.com/worldcoin/world-id-onchain-template/blob/main/contracts/src/Contract.sol)
    - takes in Solana pubkey as a signal and hashes its hex before invoking CPI call to `solana-world-id-program/verify_groth16_proof` 
    - inits a PDA using `nullifierHash` as a seed and sets `used` byte to true as a uniqueness check
    - rejects if`nullifierHash` PDA is used before proceeding to the core logic
3. Tests for `verify_and_execute` that runs after `solana-world-id-program.ts`