### PR TITLE
programs: mark refund_recipient as mut

### DIFF
--- a/programs/solana-world-id-program/src/instructions/clean_up_root.rs
+++ b/programs/solana-world-id-program/src/instructions/clean_up_root.rs
@@ -33,7 +33,7 @@ pub struct CleanUpRoot<'info> {
     config: Account<'info, Config>,
 
     /// CHECK: This account is the refund recipient for the above root.
-    #[account(address = root.refund_recipient)]
+    #[account(mut, address = root.refund_recipient)]
     refund_recipient: AccountInfo<'info>,
 }
 

--- a/programs/solana-world-id-program/src/instructions/close_signatures.rs
+++ b/programs/solana-world-id-program/src/instructions/close_signatures.rs
@@ -7,7 +7,7 @@ pub struct CloseSignatures<'info> {
     #[account(mut, has_one = refund_recipient, close = refund_recipient)]
     guardian_signatures: Account<'info, GuardianSignatures>,
 
-    #[account(address = guardian_signatures.refund_recipient)]
+    #[account(mut, address = guardian_signatures.refund_recipient)]
     refund_recipient: Signer<'info>,
 }
 

--- a/programs/solana-world-id-program/src/instructions/update_root_with_query.rs
+++ b/programs/solana-world-id-program/src/instructions/update_root_with_query.rs
@@ -103,7 +103,7 @@ pub struct UpdateRootWithQuery<'info> {
     config: Account<'info, Config>,
 
     /// CHECK: This account is the refund recipient for the above signature_set
-    #[account(address = guardian_signatures.refund_recipient)]
+    #[account(mut, address = guardian_signatures.refund_recipient)]
     refund_recipient: AccountInfo<'info>,
 
     system_program: Program<'info, System>,

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,6 +46,7 @@ The goal of these tests is to provide positive and negative cases for account an
   - [x] Rejects invalid response result length
 - [x] [clean_up_root](/programs/solana-world-id-program/src/instructions/clean_up_root.rs)
   - [x] Successfully cleans up an expired root
+  - [x] Rejects non-payer refund recipient
   - [x] Rejects non root account
   - [x] Rejects refund recipient account mismatch
   - [x] Rejects latest root clean up

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,7 +46,7 @@ The goal of these tests is to provide positive and negative cases for account an
   - [x] Rejects invalid response result length
 - [x] [clean_up_root](/programs/solana-world-id-program/src/instructions/clean_up_root.rs)
   - [x] Successfully cleans up an expired root
-  - [x] Rejects non-payer refund recipient
+  - [x] Successfully cleans up with non-payer refund recipient
   - [x] Rejects non root account
   - [x] Rejects refund recipient account mismatch
   - [x] Rejects latest root clean up

--- a/tests/solana-world-id-program.ts
+++ b/tests/solana-world-id-program.ts
@@ -1513,6 +1513,27 @@ describe("solana-world-id-program", () => {
   );
 
   it(
+    fmtTest("clean_up_root", "Rejects non-payer refund recipient"),
+    async () => {
+      const otherPayerProgram = programPaidBy(next_owner);
+      await expect(
+        otherPayerProgram.methods
+          .cleanUpRoot()
+          .accountsPartial({
+            root: deriveRootKey(
+              program.programId,
+              Buffer.from(rootHash, "hex"),
+              0
+            ),
+          })
+          .rpc()
+      ).to.be.rejectedWith(
+        "instruction changed the balance of a read-only account"
+      );
+    }
+  );
+
+  it(
     fmtTest("clean_up_root", "Successfully cleans up an expired root"),
     async () => {
       await sleep(1000);


### PR DESCRIPTION
This PR updates the refund_recipient as `mut` since it is used by a `close` constraint which will modify the account balance. Without this, anchor will not mark the account as mutable in the IDL / instruction and the instruction will fail, as shown by the first commit.