### PR TITLE
programs: reject empty guardian signatures

### DIFF
--- a/programs/solana-world-id-program/src/error.rs
+++ b/programs/solana-world-id-program/src/error.rs
@@ -34,6 +34,9 @@ pub enum SolanaWorldIDProgramError {
     #[msg("InvalidGuardianKeyRecovery")]
     InvalidGuardianKeyRecovery = 0x107,
 
+    #[msg("EmptyGuardianSignatures")]
+    EmptyGuardianSignatures = 0x108,
+
     #[msg("FailedToParseResponse")]
     FailedToParseResponse = 0x110,
 

--- a/programs/solana-world-id-program/src/instructions/post_signatures.rs
+++ b/programs/solana-world-id-program/src/instructions/post_signatures.rs
@@ -18,6 +18,20 @@ pub struct PostSignatures<'info> {
     system_program: Program<'info, System>,
 }
 
+impl<'info> PostSignatures<'info> {
+    pub fn constraints(guardian_signatures: &Vec<[u8; 66]>) -> Result<()> {
+        // Signatures should not be empty, since this is used by is_initialized.
+        // Additionally, there is no reason for it to be.
+        require!(
+            !guardian_signatures.is_empty(),
+            SolanaWorldIDProgramError::EmptyGuardianSignatures
+        );
+
+        // Done.
+        Ok(())
+    }
+}
+
 /// Creates or appends to a GuardianSignatures account for subsequent use by update_root_with_query.
 /// This is necessary as the Wormhole query response (220 bytes)
 /// and 13 guardian signatures (a quorum of the current 19 mainnet guardians, 66 bytes each)
@@ -28,6 +42,7 @@ pub struct PostSignatures<'info> {
 ///
 /// The GuardianSignatures account can be closed by anyone with a successful update_root_with_query instruction
 /// or by the initial payer via close_signatures, either of which will refund the initial payer.
+#[access_control(PostSignatures::constraints(&guardian_signatures))]
 pub fn post_signatures(
     ctx: Context<PostSignatures>,
     mut guardian_signatures: Vec<[u8; 66]>,

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,6 +12,7 @@ The goal of these tests is to provide positive and negative cases for account an
   - [x] Successfully posts signatures
   - [x] Successfully appends signatures
   - [x] Rejects append by non-initial payer
+  - [x] Rejects empty signatures
 - [x] [update_root_with_query](/programs/solana-world-id-program/src/instructions/update_root_with_query.rs)
   - [x] Successfully verifies mock queries and updates root
   - [x] Successfully closed the signature set

--- a/tests/solana-world-id-program.ts
+++ b/tests/solana-world-id-program.ts
@@ -322,6 +322,13 @@ describe("solana-world-id-program", () => {
     }
   );
 
+  it(fmtTest("post_signatures", "Rejects empty signatures"), async () => {
+    const signatureSet = anchor.web3.Keypair.generate();
+    await expect(postQuerySigs([], signatureSet, 2)).to.be.rejectedWith(
+      "EmptyGuardianSignatures."
+    );
+  });
+
   it(
     fmtTest(
       "update_root_with_query",


### PR DESCRIPTION
This PR prevents potential re-initialization of `GuardianSignatures` if the initial payer called `post_signatures` with an empty vector. Since there is no reason to do so, this PR adds a constraint to explicitly block posting an empty vector.