### PR TITLE
programs: latest roots are always valid

### DIFF
--- a/app/cleanup.ts
+++ b/app/cleanup.ts
@@ -5,6 +5,7 @@ import { BN } from "bn.js";
 import { Logger } from "winston";
 import { SolanaWorldIdProgram } from "../target/types/solana_world_id_program";
 import { deriveConfigKey } from "../tests/helpers/config";
+import { deriveLatestRootKey } from "../tests/helpers/latestRoot";
 
 export async function cleanUpRoots(
   program: Program<SolanaWorldIdProgram>,
@@ -14,6 +15,7 @@ export async function cleanUpRoots(
   const config = await program.account.config.fetch(
     deriveConfigKey(program.programId)
   );
+  const latestRoot = deriveLatestRootKey(program.programId, 0);
   const slot = await program.provider.connection.getSlot();
   const blockTime = new BN(
     await program.provider.connection.getBlockTime(slot)
@@ -36,7 +38,7 @@ export async function cleanUpRoots(
       try {
         const tx = await program.methods
           .cleanUpRoot()
-          .accounts({ root: root.publicKey })
+          .accounts({ root: root.publicKey, latestRoot: latestRoot })
           .rpc();
         logger.info(
           `Cleaned up root ${rootHex} account ${root.publicKey.toString()} in tx ${tx}`

--- a/programs/solana-world-id-program/src/error.rs
+++ b/programs/solana-world-id-program/src/error.rs
@@ -85,6 +85,9 @@ pub enum SolanaWorldIDProgramError {
     #[msg("RootUnexpired")]
     RootUnexpired = 0x126,
 
+    #[msg("RootIsLatest")]
+    RootIsLatest = 0x127,
+
     #[msg("RootExpired")]
     RootExpired = 0x200,
 

--- a/programs/solana-world-id-program/src/state/latest_root.rs
+++ b/programs/solana-world-id-program/src/state/latest_root.rs
@@ -12,7 +12,7 @@ pub struct LatestRoot {
     pub read_block_time: u64,
     /// Root hash of the last posted root account.
     pub root: [u8; 32],
-    /// SEED: Verification type. Stored for off-chain convenience.
+    /// SEED: Verification type.
     pub verification_type: [u8; 1],
 }
 

--- a/programs/solana-world-id-program/src/state/root.rs
+++ b/programs/solana-world-id-program/src/state/root.rs
@@ -12,9 +12,9 @@ pub struct Root {
     pub read_block_time: u64,
     /// Payer of this root account, used for reimbursements upon cleanup.
     pub refund_recipient: Pubkey,
-    /// SEED: Root hash. Stored for off-chain convenience.
+    /// SEED: Root hash.
     pub root: [u8; 32],
-    /// SEED: Verification type. Stored for off-chain convenience.
+    /// SEED: Verification type.
     pub verification_type: [u8; 1],
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,6 +47,7 @@ The goal of these tests is to provide positive and negative cases for account an
   - [x] Successfully cleans up an expired root
   - [x] Rejects non root account
   - [x] Rejects refund recipient account mismatch
+  - [x] Rejects latest root clean up
   - [x] Rejects active root clean up
 - [x] [close_signatures](/programs/solana-world-id-program/src/instructions/close_signatures.rs)
   - [x] Successfully closes signature accounts
@@ -75,8 +76,9 @@ The goal of these tests is to provide positive and negative cases for account an
   - [x] Rejects without owner as signer
 - [x] [verify_groth16_proof](/programs/solana-world-id-program/src/instructions/admin.rs)
   - [x] Successfully verifies a valid groth16 proof
+  - [x] Successfully verifies against an expired, but latest root
   - [x] Rejects root hash without a corresponding PDA
   - [x] Rejects root hash instruction argument mismatch
   - [x] Rejects verification type instruction argument mismatch
-  - [x] Rejects an expired root
+  - [x] Rejects an expired, non-latest root
   - [x] Rejects an invalid proof


### PR DESCRIPTION
This PR brings the Solana root validity checking in line with the [EVM WorldBridgeID implementation](https://github.com/worldcoin/world-id-state-bridge/blob/main/src/abstract/WorldIDBridge.sol#L131-L134). Previously, the Solana program only relied on checking the root expiry. Now it will consider a root valid if it is not expired *or* if it is the latest root. This comes at the cost of passing an additional account to the `cleanUpRoot` and `verifyGroth16Proof` instructions.